### PR TITLE
Better error handling

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,6 +88,9 @@ GEM
     rspec-expectations (3.2.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.2.0)
+    rspec-its (1.2.0)
+      rspec-core (>= 3.0.0)
+      rspec-expectations (>= 3.0.0)
     rspec-mocks (3.2.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.2.0)
@@ -131,6 +134,7 @@ DEPENDENCIES
   pry
   pry-byebug
   rspec (~> 3.1)
+  rspec-its (~> 1.2)
   rubocop (~> 0.32)
   webmock (~> 1.20)
 

--- a/creditsafe.gemspec
+++ b/creditsafe.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler', '~> 1.3'
   spec.add_development_dependency 'rspec', '~> 3.1'
+  spec.add_development_dependency 'rspec-its', '~> 1.2'
   spec.add_development_dependency 'guard-rspec', '~> 4.5'
   spec.add_development_dependency 'guard-rubocop', '~> 1.2'
   spec.add_development_dependency 'rubocop', '~> 0.32'

--- a/lib/creditsafe/messages.rb
+++ b/lib/creditsafe/messages.rb
@@ -69,7 +69,11 @@ module Creditsafe
     def self.for_code(code)
       padded_code = code.rjust(6, '0')
       message = ALL.find { |msg| msg.code == padded_code }
-      raise ArgumentError, "Unknown code '#{code}'" unless message
+
+      if message.nil?
+        message = Message.new(code: code, message: 'Unknown error', error: true)
+      end
+
       message
     end
   end

--- a/spec/creditsafe/messages_spec.rb
+++ b/spec/creditsafe/messages_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+require 'creditsafe/messages'
+
+RSpec.describe(Creditsafe::Messages) do
+  describe "#for_code" do
+    subject(:message) { described_class.for_code(code) }
+
+    context "for a valid code" do
+      let(:code) { "020101" }
+      its(:code) { is_expected.to eq(code) }
+      its(:message) { is_expected.to eq('Invalid credentials') }
+    end
+
+    context "for a code without leading zero" do
+      let(:code) { "20101" }
+      its(:code) { is_expected.to eq("0#{code}") }
+      its(:message) { is_expected.to eq('Invalid credentials') }
+    end
+
+    context "for an unknown code" do
+      let(:code) { "999999" }
+      its(:code) { is_expected.to eq(code) }
+      its(:message) { is_expected.to eq('Unknown error') }
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 require 'webmock/rspec'
 require 'nokogiri'
+require 'rspec/its'
 
 def load_fixture(name)
   File.read(File.join(File.dirname(__FILE__), 'fixtures', name))


### PR DESCRIPTION
Adds in the "Invalid custom data" error that we've seen, and propagates unknown codes as `ApiError`s, rather than `ArgumentError`s (the former will cause the job to get retried automatically).

@alan, please review.
