### PR TITLE
Fix ruby 2.2 warnings

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -4,3 +4,5 @@ machine:
 test:
   pre:
     - bundle exec rubocop
+  post:
+    - bundle exec rspec 

--- a/lib/creditsafe/messages.rb
+++ b/lib/creditsafe/messages.rb
@@ -2,7 +2,9 @@ module Creditsafe
   module Messages
     class Message
       attr_reader :code, :message
-      def initialize(code: code, message: message, error: false)
+      def initialize(code: nil, message: nil, error: false)
+        raise ArgumentError, "Parameters 'code' and 'message' are mandatory" \
+                             unless code && message
         @code = code
         @message = message
         @error = error

--- a/spec/creditsafe/messages_spec.rb
+++ b/spec/creditsafe/messages_spec.rb
@@ -22,5 +22,12 @@ RSpec.describe(Creditsafe::Messages) do
       its(:code) { is_expected.to eq(code) }
       its(:message) { is_expected.to eq('Unknown error') }
     end
+
+    context "for an empty code" do
+      let(:code) { '' }
+      it "was passed the wrong parameters" do
+        expect { subject(:message) }.to raise_error
+      end
+    end
   end
 end


### PR DESCRIPTION
The default parameters were variables that don't exist in the scope so
these never made much sense. Ruby 2.2 catches these as warnings so it's
probably a good idea to start fixing them now.

@alan /@matt-thomson review? (I added both as it seems that both of you have worked with this code base recently)
