### PR TITLE
Support searching with German city

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,9 +12,7 @@ GEM
     akami (1.3.1)
       gyoku (>= 0.4.0)
       nokogiri
-    ast (2.0.0)
-    astrolabe (1.3.0)
-      parser (>= 2.2.0.pre.3, < 3.0)
+    ast (2.2.0)
     builder (3.2.2)
     byebug (4.0.5)
       columnize (= 0.9.0)
@@ -64,8 +62,8 @@ GEM
     notiffany (0.0.6)
       nenv (~> 0.1)
       shellany (~> 0.0)
-    parser (2.2.2.5)
-      ast (>= 1.1, < 3.0)
+    parser (2.3.0.6)
+      ast (~> 2.2)
     powerpack (0.1.1)
     pry (0.10.1)
       coderay (~> 1.1.0)
@@ -75,7 +73,7 @@ GEM
       byebug (~> 4.0)
       pry (~> 0.10)
     rack (1.6.1)
-    rainbow (2.0.0)
+    rainbow (2.1.0)
     rb-fsevent (0.9.5)
     rb-inotify (0.9.5)
       ffi (>= 0.5.0)
@@ -95,12 +93,12 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.2.0)
     rspec-support (3.2.2)
-    rubocop (0.32.0)
-      astrolabe (~> 1.3)
-      parser (>= 2.2.2.5, < 3.0)
+    rubocop (0.37.2)
+      parser (>= 2.3.0.4, < 3.0)
       powerpack (~> 0.1)
       rainbow (>= 1.99.1, < 3.0)
-      ruby-progressbar (~> 1.4)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (~> 0.3)
     ruby-progressbar (1.7.5)
     safe_yaml (1.0.4)
     savon (2.11.1)
@@ -116,6 +114,7 @@ GEM
     thor (0.19.1)
     timers (4.0.1)
       hitimes
+    unicode-display_width (0.3.1)
     wasabi (3.5.0)
       httpi (~> 2.0)
       nokogiri (>= 1.4.2)
@@ -135,8 +134,8 @@ DEPENDENCIES
   pry-byebug
   rspec (~> 3.1)
   rspec-its (~> 1.2)
-  rubocop (~> 0.32)
+  rubocop (~> 0.37)
   webmock (~> 1.20)
 
 BUNDLED WITH
-   1.10.4
+   1.10.6

--- a/creditsafe.gemspec
+++ b/creditsafe.gemspec
@@ -25,6 +25,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec-its', '~> 1.2'
   spec.add_development_dependency 'guard-rspec', '~> 4.5'
   spec.add_development_dependency 'guard-rubocop', '~> 1.2'
-  spec.add_development_dependency 'rubocop', '~> 0.32'
+  spec.add_development_dependency 'rubocop', '~> 0.37'
   spec.add_development_dependency 'webmock', '~> 1.20'
 end

--- a/lib/creditsafe/messages.rb
+++ b/lib/creditsafe/messages.rb
@@ -1,7 +1,8 @@
 module Creditsafe
   module Messages
     class Message
-      attr_reader :code, :message
+      attr_reader :code, :message, :error
+
       def initialize(code: nil, message: nil, error: false)
         raise ArgumentError, "Parameters 'code' and 'message' are mandatory" \
                              unless code && message
@@ -10,9 +11,7 @@ module Creditsafe
         @error = error
       end
 
-      def error?
-        @error
-      end
+      alias error? error
     end
 
     # rubocop:disable Metrics/LineLength

--- a/spec/creditsafe/client_spec.rb
+++ b/spec/creditsafe/client_spec.rb
@@ -1,7 +1,8 @@
 require 'spec_helper'
 require 'creditsafe/client'
 
-URL = 'https://webservices.creditsafe.com/GlobalData/1.3/MainServiceBasic.svc'
+URL = 'https://webservices.creditsafe.com/GlobalData/1.3/'\
+      'MainServiceBasic.svc'.freeze
 
 RSpec.describe(Creditsafe::Client) do
   let(:username) { "b" }
@@ -84,10 +85,15 @@ RSpec.describe(Creditsafe::Client) do
     let(:client) { described_class.new(username: username, password: password) }
     let(:country_code) { "GB" }
     let(:registration_number) { "RN123" }
-    let(:find_company) do
-      client.find_company(country_code: country_code,
-                          registration_number: registration_number)
+    let(:city) { nil }
+    let(:search_criteria) do
+      {
+        country_code: country_code,
+        registration_number: registration_number,
+        city: city
+      }.reject { |_, v| v.nil? }
     end
+    let(:find_company) { client.find_company(search_criteria) }
     let(:method_call) { find_company }
     before do
       stub_request(:post, URL).to_return(
@@ -107,6 +113,16 @@ RSpec.describe(Creditsafe::Client) do
     context "without a registration_number" do
       let(:registration_number) { nil }
       it { is_expected.to raise_error(ArgumentError) }
+    end
+
+    context "with a city" do
+      let(:city) { "Berlin" }
+      it { is_expected.to raise_error(ArgumentError) }
+
+      context "in Germany" do
+        let(:country_code) { "DE" }
+        it { is_expected.to_not raise_error }
+      end
     end
 
     it 'returns the company details' do


### PR DESCRIPTION
In Germany, different local courts may issue the same registration number to multiple different companies. To help distinguish, Creditsafe allows you to pass the city of the company.

This PR. updates the `Creditsafe::Client.find_company` to support passing a city. I've tested it against Creditsafe.
