### PR TITLE
More specific error handling

### DIFF
--- a/lib/creditsafe/client.rb
+++ b/lib/creditsafe/client.rb
@@ -123,7 +123,7 @@ module Creditsafe
         api_error_message = api_message.message
         api_error_message += " (#{message.text})" unless message.text.blank?
 
-        raise ApiError, api_error_message if api_message.error?
+        raise api_message.error_class, api_error_message if api_message.error?
       end
     end
 
@@ -141,12 +141,12 @@ module Creditsafe
     def handle_error(error)
       raise error
     rescue Savon::SOAPFault => error
-      raise ApiError, error.message
+      raise UnknownApiError, error.message
     rescue Savon::HTTPError => error
       if error.to_hash[:code] == 401
-        raise ApiError, 'Unauthorized: invalid credentials'
+        raise AccountError, 'Unauthorized: invalid credentials'
       end
-      raise ApiError, error.message
+      raise UnknownApiError, error.message
     rescue Excon::Errors::Error => err
       raise HttpError, "Error making HTTP request: #{err.message}"
     end

--- a/lib/creditsafe/errors.rb
+++ b/lib/creditsafe/errors.rb
@@ -1,6 +1,12 @@
 module Creditsafe
   class Error < StandardError; end
 
-  class ApiError < Error; end
   class HttpError < Error; end
+  class ApiError < Error; end
+
+  class DataError < ApiError; end
+  class AccountError < ApiError; end
+  class RequestError < ApiError; end
+  class ProcessingError < ApiError; end
+  class UnknownApiError < ApiError; end
 end

--- a/lib/creditsafe/messages.rb
+++ b/lib/creditsafe/messages.rb
@@ -1,3 +1,5 @@
+require 'creditsafe/errors'
+
 module Creditsafe
   module Messages
     class Message
@@ -12,6 +14,18 @@ module Creditsafe
       end
 
       alias error? error
+
+      def error_class
+        return unless error?
+
+        case code[1].to_i
+        when 1 then Creditsafe::DataError
+        when 2 then Creditsafe::AccountError
+        when 3 then Creditsafe::RequestError
+        when 4 then Creditsafe::ProcessingError
+        else Creditsafe::UnknownApiError
+        end
+      end
     end
 
     # rubocop:disable Metrics/LineLength

--- a/spec/creditsafe/client_spec.rb
+++ b/spec/creditsafe/client_spec.rb
@@ -17,14 +17,14 @@ RSpec.describe(Creditsafe::Client) do
         )
       end
 
-      it 'raises an ApiError' do
-        expect { method_call }.to raise_error(Creditsafe::ApiError)
+      it 'raises an AccountError' do
+        expect { method_call }.to raise_error(Creditsafe::AccountError)
       end
 
       it 'gives a useful error message' do
         begin
           method_call
-        rescue Creditsafe::ApiError => err
+        rescue Creditsafe::AccountError => err
           expect(err.message).to include 'invalid credentials'
         end
       end
@@ -36,8 +36,8 @@ RSpec.describe(Creditsafe::Client) do
           to_return(body: load_fixture('error-fault.xml'))
       end
 
-      it 'raises an ApiError' do
-        expect { method_call }.to raise_error(Creditsafe::ApiError)
+      it 'raises an UnknownApiError' do
+        expect { method_call }.to raise_error(Creditsafe::UnknownApiError)
       end
     end
 
@@ -170,7 +170,7 @@ RSpec.describe(Creditsafe::Client) do
       it 'gives a useful error, with the specific error in the response' do
         begin
           method_call
-        rescue Creditsafe::ApiError => err
+        rescue Creditsafe::RequestError => err
           expect(err.message).to eq 'Invalid operation parameters ' \
                                     '(Invalid countries list specified.)'
         end
@@ -187,7 +187,7 @@ RSpec.describe(Creditsafe::Client) do
         it 'gives a useful error, with the specific error in the response' do
           begin
             method_call
-          rescue Creditsafe::ApiError => err
+          rescue Creditsafe::RequestError => err
             expect(err.message).to eq 'Invalid operation parameters'
           end
         end
@@ -221,14 +221,14 @@ RSpec.describe(Creditsafe::Client) do
           to_return(body: load_fixture('company-report-not-found.xml'))
       end
 
-      it 'returns nil' do
-        expect { company_report }.to raise_error(Creditsafe::ApiError)
+      it 'raises an error' do
+        expect { company_report }.to raise_error(Creditsafe::DataError)
       end
 
       it 'gives a useful error message' do
         begin
           company_report
-        rescue Creditsafe::ApiError => err
+        rescue Creditsafe::DataError => err
           expect(err.message).to include 'Report unavailable'
         end
       end

--- a/spec/creditsafe/messages_spec.rb
+++ b/spec/creditsafe/messages_spec.rb
@@ -2,31 +2,66 @@ require 'spec_helper'
 require 'creditsafe/messages'
 
 RSpec.describe(Creditsafe::Messages) do
-  describe "#for_code" do
+  describe ".for_code" do
     subject(:message) { described_class.for_code(code) }
 
     context "for a valid code" do
       let(:code) { "020101" }
       its(:code) { is_expected.to eq(code) }
       its(:message) { is_expected.to eq('Invalid credentials') }
+      its(:error_class) { is_expected.to eq(Creditsafe::AccountError) }
     end
 
     context "for a code without leading zero" do
       let(:code) { "20101" }
       its(:code) { is_expected.to eq("0#{code}") }
       its(:message) { is_expected.to eq('Invalid credentials') }
+      its(:error_class) { is_expected.to eq(Creditsafe::AccountError) }
     end
 
     context "for an unknown code" do
       let(:code) { "999999" }
       its(:code) { is_expected.to eq(code) }
       its(:message) { is_expected.to eq('Unknown error') }
+      its(:error_class) { is_expected.to eq(Creditsafe::UnknownApiError) }
     end
 
     context "for an empty code" do
       let(:code) { '' }
       it "was passed the wrong parameters" do
         expect { subject(:message) }.to raise_error
+      end
+    end
+  end
+
+  describe(Creditsafe::Messages::Message) do
+    subject(:message) do
+      described_class.new(code: code, message: text, error: error)
+    end
+    let(:text) { "Error message" }
+    let(:code) { "020101" }
+    let(:error) { true }
+
+    describe "#error_class" do
+      subject { message.error_class }
+
+      context "when there is no error" do
+        let(:error) { false }
+        it { is_expected.to be_nil }
+      end
+
+      context "when there is an error" do
+        let(:error) { true }
+
+        context "for a processing error code" do
+          let(:code) { "040102" }
+          it { is_expected.to eq(Creditsafe::ProcessingError) }
+        end
+
+        context "for an unknown error code" do
+          let(:code) { "060102" }
+          it { is_expected.to eq(Creditsafe::UnknownApiError) }
+        end
       end
     end
   end


### PR DESCRIPTION
Currently we raise an `ApiError` for all failures that come from Creditsafe. This PR subclasses that error so that different kinds of Creditsafe errors can be easily distinguished.