### PR TITLE
Suppress password when inspecting client

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,9 +16,3 @@ Style/DotPosition:
 
 Style/Documentation:
   Enabled: false
-
-Metrics/MethodLength:
-  Max: 15
-
-Metrics/ClassLength:
-  Max: 152

--- a/lib/creditsafe/client.rb
+++ b/lib/creditsafe/client.rb
@@ -55,6 +55,10 @@ module Creditsafe
         fetch(:report)
     end
 
+    def inspect
+      "#<#{self.class} @username='#{@username}'>"
+    end
+
     private
 
     def check_search_criteria(search_criteria)

--- a/lib/creditsafe/namespace.rb
+++ b/lib/creditsafe/namespace.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Creditsafe
+  module Namespace
+    OPER = 'oper'
+    OPER_VAL = 'http://www.creditsafe.com/globaldata/operations'
+
+    DAT = 'dat'
+    DAT_VAL = 'http://www.creditsafe.com/globaldata/datatypes'
+
+    CRED = 'cred'
+    CRED_VAL = 'http://schemas.datacontract.org/2004/07/Creditsafe.GlobalData'
+
+    ALL = {
+      "xmlns:#{Creditsafe::Namespace::OPER}" => Creditsafe::Namespace::OPER_VAL,
+      "xmlns:#{Creditsafe::Namespace::DAT}" => Creditsafe::Namespace::DAT_VAL,
+      "xmlns:#{Creditsafe::Namespace::CRED}" => Creditsafe::Namespace::CRED_VAL
+    }.freeze
+  end
+end

--- a/lib/creditsafe/request/company_report.rb
+++ b/lib/creditsafe/request/company_report.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'creditsafe/namespace'
+
+module Creditsafe
+  module Request
+    class CompanyReport
+      def initialize(company_id, custom_data)
+        @company_id = company_id
+        @custom_data = custom_data
+      end
+
+      def message
+        message = {
+          "#{Creditsafe::Namespace::OPER}:companyId" => company_id.to_s,
+          "#{Creditsafe::Namespace::OPER}:reportType" => 'Full',
+          "#{Creditsafe::Namespace::OPER}:language" => "EN"
+        }
+
+        unless custom_data.nil?
+          message["#{Creditsafe::Namespace::OPER}:customData"] = {
+            "#{Creditsafe::Namespace::DAT}:Entries" => {
+              "#{Creditsafe::Namespace::DAT}:Entry" => custom_data_entries
+            }
+          }
+        end
+
+        message
+      end
+
+      private
+
+      def custom_data_entries
+        custom_data.map { |key, value| { :@key => key, :content! => value } }
+      end
+
+      attr_reader :company_id, :custom_data
+    end
+  end
+end

--- a/lib/creditsafe/request/find_company.rb
+++ b/lib/creditsafe/request/find_company.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'creditsafe/namespace'
+
+module Creditsafe
+  module Request
+    class FindCompany
+      def initialize(search_criteria)
+        check_search_criteria(search_criteria)
+
+        @country_code = search_criteria[:country_code]
+        @registration_number = search_criteria[:registration_number]
+        @city = search_criteria[:city]
+      end
+
+      def message
+        search_criteria = {
+          "#{Creditsafe::Namespace::DAT}:RegistrationNumber" =>
+            registration_number
+        }
+
+        unless city.nil?
+          search_criteria["#{Creditsafe::Namespace::DAT}:Address"] =
+            { "#{Creditsafe::Namespace::DAT}:City" => city }
+        end
+
+        {
+          "#{Creditsafe::Namespace::OPER}:countries" => {
+            "#{Creditsafe::Namespace::CRED}:CountryCode" => country_code
+          },
+          "#{Creditsafe::Namespace::OPER}:searchCriteria" => search_criteria
+        }
+      end
+
+      private
+
+      attr_reader :country_code, :registration_number, :city
+
+      def check_search_criteria(search_criteria)
+        if search_criteria[:country_code].nil?
+          raise ArgumentError, "country_code is a required search criteria"
+        end
+
+        if search_criteria[:registration_number].nil?
+          raise ArgumentError,
+                "registration_number is a required search criteria"
+        end
+
+        if search_criteria[:city] && search_criteria[:country_code] != 'DE'
+          raise ArgumentError, "city is only supported for German searches"
+        end
+      end
+    end
+  end
+end

--- a/spec/creditsafe/client_spec.rb
+++ b/spec/creditsafe/client_spec.rb
@@ -8,8 +8,8 @@ URL = 'https://webservices.creditsafe.com/GlobalData/1.3/'\
 
 RSpec.describe(Creditsafe::Client) do
   notifications = []
-  let(:username) { "b" }
-  let(:password) { "c" }
+  let(:username) { "AzureDiamond" }
+  let(:password) { "hunter2" }
   before(:all) do
     ActiveSupport::Notifications.subscribe do |*args|
       notifications << ActiveSupport::Notifications::Event.new(*args)
@@ -105,8 +105,6 @@ RSpec.describe(Creditsafe::Client) do
     subject do
       -> { described_class.new(username: username, password: password) }
     end
-    let(:username) { "foo" }
-    let(:password) { "bar" }
 
     it { is_expected.to_not raise_error }
 
@@ -114,11 +112,13 @@ RSpec.describe(Creditsafe::Client) do
       let(:username) { nil }
       it { is_expected.to raise_error(ArgumentError) }
     end
+  end
 
-    context "without a password" do
-      let(:password) { nil }
-      it { is_expected.to raise_error(ArgumentError) }
-    end
+  describe "#inspect" do
+    let(:client) { described_class.new(username: username, password: password) }
+    subject { client.inspect }
+
+    it { is_expected.to_not include(password) }
   end
 
   describe '#find_company' do


### PR DESCRIPTION
This prevents the password from being logged to console in error.

First commit contains the actual change.  This tipped us over the maximum class length as enforced by Rubocop - took that as a signal to do some refactoring, in the following two commits.  We're now within Rubocop's default maximums for class and method length, so I've taken out our overrides in the final commit.

Have done a sanity check of this through our checker with our test credentials, and all works.