### PR TITLE
Fix Rubocop failures

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,3 +16,6 @@ Style/DotPosition:
 
 Style/Documentation:
   Enabled: false
+
+Metrics/LineLength:
+  Max: 90

--- a/lib/creditsafe/client.rb
+++ b/lib/creditsafe/client.rb
@@ -16,10 +16,15 @@ module Creditsafe
   class Client
     ENVIRONMENTS = %i(live test).freeze
 
-    def initialize(username: nil, password: nil, savon_opts: {}, environment: :live, log_level: :warn)
+    def initialize(username: nil, password: nil, savon_opts: {},
+                   environment: :live, log_level: :warn)
       raise ArgumentError, "Username must be provided" if username.nil?
       raise ArgumentError, "Password must be provided" if password.nil?
-      raise ArgumentError, "Environment needs to be one of #{ENVIRONMENTS.join('/')}" unless ENVIRONMENTS.include?(environment.to_sym)
+
+      unless ENVIRONMENTS.include?(environment.to_sym)
+        raise ArgumentError, "Environment needs to be one of #{ENVIRONMENTS.join('/')}"
+      end
+
       @environment = environment.to_s
       @log_level = log_level
       @username = username
@@ -129,7 +134,7 @@ module Creditsafe
         adapter: :excon,
         log: true,
         log_level: @log_level,
-        pretty_print_xml: true,
+        pretty_print_xml: true
       }
       Savon.client(options.merge(@savon_opts))
     end

--- a/lib/creditsafe/request/find_company.rb
+++ b/lib/creditsafe/request/find_company.rb
@@ -21,12 +21,23 @@ module Creditsafe
           :content! => company_name
         } unless company_name.nil?
 
-        search_criteria["#{Creditsafe::Namespace::DAT}:RegistrationNumber"] = registration_number unless registration_number.nil?
+        unless registration_number.nil?
+          search_criteria["#{Creditsafe::Namespace::DAT}:RegistrationNumber"] =
+            registration_number
+        end
 
         search_criteria["#{Creditsafe::Namespace::DAT}:Address"] = {
           "#{Creditsafe::Namespace::DAT}:City" => city
         } unless city.nil?
 
+        build_message(search_criteria)
+      end
+
+      private
+
+      attr_reader :country_code, :registration_number, :city, :company_name
+
+      def build_message(search_criteria)
         {
           "#{Creditsafe::Namespace::OPER}:countries" => {
             "#{Creditsafe::Namespace::CRED}:CountryCode" => country_code
@@ -35,15 +46,29 @@ module Creditsafe
         }
       end
 
-      private
-
-      attr_reader :country_code, :registration_number, :city, :company_name
-
+      # rubocop:disable Style/CyclomaticComplexity, Metrics/AbcSize
       def check_search_criteria(search_criteria)
-        raise ArgumentError, "country_code is a required search criteria" if search_criteria[:country_code].nil?
-        raise ArgumentError, "company name search is only possible for German searches" if search_criteria[:country_code] != 'DE' && !search_criteria[:company_name].nil?
-        raise ArgumentError, "registration_number or company_name (not both) are required search criteria" unless search_criteria[:registration_number].nil? ^ search_criteria[:company_name].nil?
-        raise ArgumentError, "city is only supported for German searches" if search_criteria[:city] && search_criteria[:country_code] != 'DE'
+        if search_criteria[:country_code].nil?
+          raise ArgumentError, "country_code is a required search criteria"
+        end
+
+        if search_criteria[:country_code] != 'DE' && !search_criteria[:company_name].nil?
+          raise ArgumentError, "company name search is only possible for German searches"
+        end
+
+        unless only_registration_number_or_company_name_provided?(search_criteria)
+          raise ArgumentError, "registration_number or company_name (not both) are " \
+                               "required search criteria"
+        end
+
+        if search_criteria[:city] && search_criteria[:country_code] != 'DE'
+          raise ArgumentError, "city is only supported for German searches"
+        end
+      end
+      # rubocop:enable Style/CyclomaticComplexity, Metrics/AbcSize
+
+      def only_registration_number_or_company_name_provided?(search_criteria)
+        search_criteria[:registration_number].nil? ^ search_criteria[:company_name].nil?
       end
     end
   end


### PR DESCRIPTION
I didn't realise that there were a bunch of failures since Circle wasn't running on the pull requests. The specs all pass (checked this when I was building the release locally) but there are some Rubocop issues.

I've taken a fairly opinionated approach in solving them, bumping the line length to something saner and disabling a few cops on one of our methods which is long, but I feel fairly sensible in situ.