### PR TITLE
Add searching by VAT number for US

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.6.0, 25 September 2018
+
+- Add searching by VAT number
+
 ## v0.5.2, 29 March 2018
 
 - Raise `Creditsafe::TimeoutError` when a request times out

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    creditsafe (0.5.2)
+    creditsafe (0.6.0)
       activesupport (>= 4.2.0)
       excon (~> 0.45)
       savon (~> 2.8)
@@ -126,4 +126,4 @@ DEPENDENCIES
   webmock (~> 3.3)
 
 BUNDLED WITH
-   1.16.1
+   1.16.5

--- a/README.md
+++ b/README.md
@@ -31,10 +31,11 @@ client = Creditsafe::Client.new(username: "foo", password: "bar", environment: :
 
 ### Company Search
 
-To perform a search for a company, you need to provide a country code and a company registration number:
+To perform a search for a company, you need to provide a valid search criteria, including
+the country code and a company registration number or company name:
 
 ```ruby
-client.find_company(country_code: "GB", registration_number: "07495895")
+client.find_company({ country_code: "GB", registration_number: "07495895" })
 => {
     name: "GOCARDLESS LTD",
     type: "Ltd",
@@ -55,11 +56,11 @@ client.find_company(country_code: "GB", registration_number: "07495895")
 ```
 
 In Germany you can also perform a name search. For this you need to provide a country code
-and a company name, and can optionally provided a postal code to filter the results
+and a company name, and can optionally provide a postal code or city to filter the results
 further:
 
 ```ruby
-client.find_company(country_code: "DE", company_name: "zalando", postal_code: "10243")
+client.find_company({ country_code: "DE", company_name: "zalando", postal_code: "10243" })
 => [
   {
     "name": "Zalando Logistics Süd SE & Co. KG",
@@ -114,6 +115,42 @@ client.find_company(country_code: "DE", company_name: "zalando", postal_code: "1
     "@country": "DE",
     "@id": "DE001/1/DE16031795",
     "@safe_number": "DE16031795"
+  },
+  ...
+]
+```
+
+In some countries you can also perform a VAT number search. For this, you need to provide
+a country code and a VAT number:
+
+```ruby
+client.find_company({ country_code: "US", vat_number: "201665019" })
+=> [
+  {
+    "name": "FACEBOOK, INCORPORATED",
+    "officeType": "HeadOffice",
+    "status": "Active",
+    "registration_number": "0883875",
+    "vat_number": "201665019",
+    "address": {
+      "simple_value": "1601 WILLOW ROAD , MENLO PARK, CA, 94025",
+      "street": "1601 WILLOW ROAD ",
+      "city": "MENLO PARK",
+      "postal_code": "94025",
+      "province": "CA"
+    },
+    "phone_number": "6505434800",
+    "available_report_types": {
+      "available_report_type": "Full"
+    },
+    "available_languages": {
+      "available_language": "EN"
+    },
+    "@online_reports": "true",
+    "@monitoring": "false",
+    "@country": "US",
+    "@id": "US023/X/US22964593",
+    "@safe_number": "US22964593"
   },
   ...
 ]

--- a/lib/creditsafe/constants.rb
+++ b/lib/creditsafe/constants.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module Constants
+  module Country
+    AUSTRALIA                 = "AU"
+    AUSTRIA                   = "AT"
+    BELGIUM                   = "BE"
+    BULGARIA                  = "BG"
+    CANADA                    = "CA"
+    CROATIA                   = "HR"
+    CZECH_REPUBLIC            = "CZ"
+    DENMARK                   = "DK"
+    ESTONIA                   = "EE"
+    FINLAND                   = "FI"
+    FRANCE                    = "FR"
+    GERMANY                   = "DE"
+    GREAT_BRITAIN             = "GB"
+    GREECE                    = "GR"
+    HUNGARY                   = "HU"
+    ICELAND                   = "IS"
+    IRELAND                   = "IE"
+    ITALY                     = "IT"
+    LATVIA                    = "LV"
+    LIECHTENSTEIN             = "LI"
+    LITHUANIA                 = "LT"
+    LUXEMBOURG                = "LU"
+    MALTA                     = "MT"
+    MOLDOVA                   = "MD"
+    NETHERLANDS               = "NL"
+    NEW_ZEALAND               = "NZ"
+    NORWAY                    = "NO"
+    POLAND                    = "PL"
+    PORTUGAL                  = "PT"
+    ROMANIA                   = "RO"
+    SLOVAKIA                  = "SK"
+    SLOVENIA                  = "SI"
+    SPAIN                     = "ES"
+    SWEDEN                    = "SE"
+    SWITZERLAND               = "CH"
+    UK                        = "GB"
+    UNITED_STATES             = "US"
+
+    VAT_NUMBER_SUPPORTED = [
+      GERMANY, FRANCE, CZECH_REPUBLIC, SLOVAKIA, BELGIUM, POLAND, PORTUGAL, SPAIN,
+      UNITED_STATES, SLOVENIA, CROATIA, BULGARIA, ROMANIA, LATVIA, ESTONIA, MOLDOVA,
+      AUSTRIA, ITALY, HUNGARY, FINLAND, DENMARK, AUSTRALIA, GREECE
+    ].freeze
+  end
+end

--- a/lib/creditsafe/request/find_company.rb
+++ b/lib/creditsafe/request/find_company.rb
@@ -2,6 +2,7 @@
 
 require "creditsafe/match_type"
 require "creditsafe/namespace"
+require "creditsafe/constants"
 
 module Creditsafe
   module Request
@@ -11,6 +12,7 @@ module Creditsafe
         @country_code = search_criteria[:country_code]
         @registration_number = search_criteria[:registration_number]
         @company_name = search_criteria[:company_name]
+        @vat_number = search_criteria[:vat_number]
         @city = search_criteria[:city]
         @postal_code = search_criteria[:postal_code]
       end
@@ -32,6 +34,11 @@ module Creditsafe
             registration_number
         end
 
+        unless vat_number.nil?
+          search_criteria["#{Creditsafe::Namespace::DAT}:VatNumber"] =
+            vat_number
+        end
+
         unless city.nil?
           search_criteria["#{Creditsafe::Namespace::DAT}:Address"] = {
             "#{Creditsafe::Namespace::DAT}:City" => city,
@@ -51,7 +58,8 @@ module Creditsafe
 
       private
 
-      attr_reader :country_code, :registration_number, :city, :company_name, :postal_code
+      attr_reader :country_code, :registration_number, :city, :company_name, :postal_code,
+                  :vat_number
 
       def match_type
         Creditsafe::MatchType::ALLOWED[country_code.upcase.to_sym]&.first ||
@@ -69,14 +77,16 @@ module Creditsafe
 
       # rubocop:disable Metrics/CyclomaticComplexity
       # rubocop:disable Metrics/MethodLength
+      # rubocop:disable Metrics/PerceivedComplexity
+      # rubocop:disable Metrics/AbcSize
       def check_search_criteria(search_criteria)
         if search_criteria[:country_code].nil?
           raise ArgumentError, "country_code is a required search criteria"
         end
 
-        unless only_registration_number_or_company_name_provided?(search_criteria)
-          raise ArgumentError, "registration_number or company_name (not both) are " \
-                               "required search criteria"
+        unless only_one_required_criteria?(search_criteria)
+          raise ArgumentError, "only one of registration_number, company_name or " \
+                               "vat number is required search criteria"
         end
 
         if search_criteria[:city] && search_criteria[:country_code] != "DE"
@@ -86,12 +96,24 @@ module Creditsafe
         if search_criteria[:postal_code] && search_criteria[:country_code] != "DE"
           raise ArgumentError, "Postal code is only supported for German searches"
         end
+
+        if search_criteria[:vat_number] && !Constants::Country::VAT_NUMBER_SUPPORTED.
+            include?(search_criteria[:country_code])
+          raise ArgumentError, "VAT number is not supported in this country"
+        end
       end
+      # rubocop:enable Metrics/AbcSize
+      # rubocop:enable Metrics/PerceivedComplexity
       # rubocop:enable Metrics/MethodLength
       # rubocop:enable Metrics/CyclomaticComplexity
 
-      def only_registration_number_or_company_name_provided?(search_criteria)
-        search_criteria[:registration_number].nil? ^ search_criteria[:company_name].nil?
+      def only_one_required_criteria?(search_criteria)
+        by_registration_number = !search_criteria[:registration_number].nil?
+        by_company_name = !search_criteria[:company_name].nil?
+        by_vat_number = !search_criteria[:vat_number].nil?
+
+        (by_registration_number ^ by_company_name ^ by_vat_number) &&
+          !(by_registration_number && by_company_name && by_vat_number)
       end
     end
   end

--- a/lib/creditsafe/version.rb
+++ b/lib/creditsafe/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Creditsafe
-  VERSION = "0.5.2"
+  VERSION = "0.6.0"
 end

--- a/spec/creditsafe/client_spec.rb
+++ b/spec/creditsafe/client_spec.rb
@@ -136,10 +136,14 @@ RSpec.describe(Creditsafe::Client) do
     let(:registration_number) { "RN123" }
     let(:city) { nil }
     let(:postal_code) { nil }
+    let(:company_name) { nil }
+    let(:vat_number) { nil }
     let(:search_criteria) do
       {
         country_code: country_code,
         registration_number: registration_number,
+        company_name: company_name,
+        vat_number: vat_number,
         city: city,
         postal_code: postal_code,
       }.reject { |_, v| v.nil? }
@@ -194,7 +198,9 @@ RSpec.describe(Creditsafe::Client) do
     end
 
     context "with a company name" do
-      let(:search_criteria) { { country_code: "FR", company_name: "Mimes Inc" } }
+      let(:country_code) { "FR" }
+      let(:registration_number) { nil }
+      let(:company_name) { "Mimes Inc" }
 
       it { is_expected.to_not raise_error }
 
@@ -208,6 +214,54 @@ RSpec.describe(Creditsafe::Client) do
         end
 
         expect(request).to have_been_made
+      end
+    end
+
+    context "with a vat_number" do
+      let(:vat_number) { "942404110" }
+      let(:registration_number) { nil }
+
+      it { is_expected.to raise_error(ArgumentError) }
+
+      context "in US" do
+        let(:country_code) { "US" }
+
+        it { is_expected.to_not raise_error }
+      end
+    end
+
+    context "with different invalid required criteria combinations used" do
+      context "with registration number and company name" do
+        let(:company_name) { "Mimes Inc" }
+
+        it { is_expected.to raise_error(ArgumentError) }
+      end
+
+      context "with registration number and vat_number" do
+        let(:vat_number) { "942404110" }
+
+        it { is_expected.to raise_error(ArgumentError) }
+      end
+
+      context "with company name and vat_number" do
+        let(:registration_number) { nil }
+        let(:company_name) { "Mimes Inc" }
+        let(:vat_number) { "942404110" }
+
+        it { is_expected.to raise_error(ArgumentError) }
+      end
+
+      context "with all three required criteria" do
+        let(:company_name) { "Mimes Inc" }
+        let(:vat_number) { "942404110" }
+
+        it { is_expected.to raise_error(ArgumentError) }
+      end
+
+      context "with no required criteria" do
+        let(:registration_number) { nil }
+
+        it { is_expected.to raise_error(ArgumentError) }
       end
     end
 


### PR DESCRIPTION
The Registration Number, Company Name and VAT Number criteria are
mutually exclusive.

Bump version to 0.6.0