### PR TITLE
v0.7.0: avoid polluting the global namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## v0.7.0, 5 October 2021
 
 - Rename Constants::Country to Creditsafe::Country, to avoid polluting other namespaces
+- Update dependencies: activesupport, excon
+- Downgrade savon
+- Require Ruby 2.7+
 
 ## v0.6.3, 18 December 2019
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.7.0, 5 October 2021
+
+- Rename Constants::Country to Creditsafe::Country, to avoid polluting other namespaces
+
 ## v0.6.3, 18 December 2019
 
 - Update dependencies: excon

--- a/creditsafe.gemspec
+++ b/creditsafe.gemspec
@@ -18,9 +18,9 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "activesupport", "~> 6.1"
+  spec.add_runtime_dependency "activesupport"
   spec.add_runtime_dependency "excon", "~> 0.85"
-  spec.add_runtime_dependency "savon", "~> 2.12"
+  spec.add_runtime_dependency "savon", "~> 2.11"
 
   spec.add_development_dependency "compare-xml", "~> 0.66"
   spec.add_development_dependency "gc_ruboconfig", "~> 2.28"

--- a/lib/creditsafe/country.rb
+++ b/lib/creditsafe/country.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Constants
+module Creditsafe
   module Country
     AUSTRALIA                 = "AU"
     AUSTRIA                   = "AT"

--- a/lib/creditsafe/request/find_company.rb
+++ b/lib/creditsafe/request/find_company.rb
@@ -2,7 +2,7 @@
 
 require "creditsafe/match_type"
 require "creditsafe/namespace"
-require "creditsafe/constants"
+require "creditsafe/country"
 
 module Creditsafe
   module Request
@@ -96,7 +96,7 @@ module Creditsafe
           raise ArgumentError, "Postal code is only supported for German searches"
         end
 
-        if search_criteria[:vat_number] && !Constants::Country::VAT_NUMBER_SUPPORTED.
+        if search_criteria[:vat_number] && !Creditsafe::Country::VAT_NUMBER_SUPPORTED.
             include?(search_criteria[:country_code])
           raise ArgumentError, "VAT number is not supported in this country"
         end

--- a/lib/creditsafe/version.rb
+++ b/lib/creditsafe/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Creditsafe
-  VERSION = "0.6.3"
+  VERSION = "0.7.0"
 end


### PR DESCRIPTION
Rename Constants::Country to Creditsafe::Country. Polluting the global
namespace can cause weird issues, like Zeitwerk refusing to load a
`Constants::Country` class if your app defines its own one.